### PR TITLE
Use Artifacts system instead of CDNs

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,13 @@
+[JuliaMono]
+git-tree-sha1 = "8730bd1d8cbb19f36e0ca10236011fd72083746f"
+
+    [[JuliaMono.download]]
+    sha256 = "255b4960fa61ccc58660603c3b8ae19f1cd9d10ecb34ea32967bb32381962931"
+    url = "https://github.com/cormullion/juliamono/archive/v0.042.tar.gz"
+
+[Highlight]
+git-tree-sha1 = "74d0a953af18dcd657e32a9cd95e77d791882528"
+
+    [[Highlight.download]]
+    sha256 = "ba979bd14d82065aebea450ed77e4b3fe217ca3a7876cc69606147b85d8fb3ce"
+    url = "https://github.com/highlightjs/cdn-release/archive/refs/tags/11.4.0.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
 version = "0.1.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 Franklin = "713c75ef-9fc9-4b05-94a9-213340da978e"
 PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 

--- a/_css/spectre-overrides.css
+++ b/_css/spectre-overrides.css
@@ -33,11 +33,6 @@ ul {
     width: 16rem !important;
 }
 
-@font-face {
-    font-family: JuliaMono-Regular;
-    src: url("https://cdnjs.cloudflare.com/ajax/libs/juliamono/0.042/JuliaMono-Regular.woff2");
-}
-
 pre {
     font-family: JuliaMono-Regular, SFMono-Regular, DejaVu Sans Mono;
     font-variant-ligatures: none;

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -6,6 +6,12 @@
   <link rel="icon" type="image/png" href="/assets/favicon.png">
   {{insert head_math.html }}
   {{insert head_highlight.html }}
+    <style>
+    @font-face {
+      font-family: JuliaMono-Regular;
+      src: url("{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}");
+    }
+    </style>
 
   <link rel="stylesheet" href="/css/spectre.min.css">
   <link rel="stylesheet" href="/css/spectre-exp.min.css">

--- a/_layout/head_highlight.html
+++ b/_layout/head_highlight.html
@@ -1,16 +1,16 @@
 <link rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/github.min.css">
+  href="{{artifact Highlight cdn-release-11.4.0 build styles github.min.css}}">
 
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js">
+  src="{{artifact Highlight cdn-release-11.4.0 build highlight.min.js}}">
 </script>
 
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/languages/julia.min.js">
+  src="{{artifact Highlight cdn-release-11.4.0 build languages julia.min.js}}">
 </script>
 
 <script
-  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/languages/julia-repl.min.js">
+  src="{{artifact Highlight cdn-release-11.4.0 build languages julia-repl.min.js}}">
 </script>
 
 <script>

--- a/utils.jl
+++ b/utils.jl
@@ -60,6 +60,7 @@ function hfun_artifact(params::Vector{String})::String
     name = params[1]
     dir = @artifact_str(name)
     from = joinpath(dir, params[2:end]...)
+    @assert isfile(from)
     location = params[2:end]
     to = joinpath(@__DIR__, "__site", "assets", name, location...)
     mkpath(dirname(to))

--- a/utils.jl
+++ b/utils.jl
@@ -1,3 +1,5 @@
+using Artifacts: @artifact_str
+
 function hfun_bar(vname)
   val = Meta.parse(vname[1])
   return round(sqrt(val), digits=2)
@@ -40,4 +42,27 @@ function lx_readhtml(com, _)
         ```
         \\textoutput{pluto}
         """
+end
+
+"""
+    hfun_artifact(params::Vector{String})::String
+
+Return a (relative) URL to an artifact.
+For example, for JuliaMono, use
+```
+{{artifact JuliaMono juliamono-0.042 webfonts JuliaMono-Regular.woff2}}
+```
+where JuliaMono is the name of the Artifact in Artifacts.toml.
+
+This method copies the artifact, puts it into `_assets` and returns a relative URL.
+"""
+function hfun_artifact(params::Vector{String})::String
+    name = params[1]
+    dir = @artifact_str(name)
+    from = joinpath(dir, params[2:end]...)
+    location = params[2:end]
+    to = joinpath(@__DIR__, "__site", "assets", name, location...)
+    mkpath(dirname(to))
+    cp(from, to; force=true)
+    return string('/', join(["assets"; name; location], '/'))
 end


### PR DESCRIPTION
In response to things like https://rewis.io/urteile/urteil/lhm-20-01-2022-3-o-1749320/ and knowing that caching has security risks and, therefore, using a CDN hurts performance due to an extra DNS lookup (https://httptoolkit.tech/blog/public-cdn-risks/).

MathJax is a bit of a problem. When Franklin doesn't parse the `hfun` call, put it away from the `head_math.html`. Next, the problem is that the CDN uses relative links it seems, so make sure to get all files