### PR TITLE
Rename module

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,20 +20,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-
     - uses: julia-actions/setup-julia@v1
     - uses: julia-actions/cache@v1
-
-    # For development purposes.
-    - if: ${{ github.repository == 'rikhuijzer/JuliaTutorialsTemplate' }}
-      run: julia --project -e 'using Pkg;
-        Pkg.add(url="https://github.com/rikhuijzer/PlutoStaticHTML.jl#main")'
-
-    - uses: julia-actions/julia-buildpkg@latest
+    - uses: julia-actions/julia-buildpkg@v1
 
     - name: Build notebooks
-      run: julia --project -e '
-        using JuliaTutorialsTemplate; build_tutorials()'
+      run: julia --project -e 'using Tutorials; build_tutorials()'
       env:
         JULIA_NUM_THREADS: '2'
         DISABLE_CACHE: '${{ github.event.inputs.disableCache }}'

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "JuliaTutorialsTemplate"
+name = "Tutorials"
 uuid = "e088c1bc-e00f-47bb-8742-48f468c16799"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
 version = "0.1.0"

--- a/getting-started.md
+++ b/getting-started.md
@@ -88,11 +88,11 @@ julia> ]
 
 pkg> activate .
 
-(JuliaTutorialsTemplate) pkg> instantiate
+(Tutorials) pkg> instantiate
 
-(JuliaTutorialsTemplate) pkg> # Press backspace to go back
+(Tutorials) pkg> # Press backspace to go back
 
-julia> using JuliaTutorialsTemplate
+julia> using Tutorials
 
 julia> build_tutorials()
 [...]

--- a/getting-started.md
+++ b/getting-started.md
@@ -69,7 +69,11 @@ title = "$title"
 
 Add these blocks in your website to let Franklin know what the page title should be.
 Also remove the old tutorials while you are in that folder.
-Next, go to the menu in `_layout/menu.html` and find the lines containing "menu-header" and "menu-item".
+
+Next, search for `JuliaTutorialsTemplate` inside your repository and replace all occurrences of that word by the name of your repository.
+It is especially important to set the right `prepath` in `config.md` since otherwise the CSS will not work on the website.
+
+Also, go to the menu in `_layout/menu.html` and find the lines containing "menu-header" and "menu-item".
 Compare these lines with how the website looks and, next, change the lines to point to your own tutorials.
 You can also decide to remove all "menu-header" entries; it depends on personal preference.
 

--- a/src/Tutorials.jl
+++ b/src/Tutorials.jl
@@ -1,8 +1,8 @@
-module JuliaTutorialsTemplate
+module Tutorials
 
 using PlutoStaticHTML
 
-const PKGDIR = pkgdir(JuliaTutorialsTemplate)
+const PKGDIR = pkgdir(Tutorials)
 
 export build_tutorials
 


### PR DESCRIPTION
This makes it easier to find what needs to be changed. After copying the repo, only all occurrences of `JuliaTutorialsTemplate` have to be updated